### PR TITLE
fix: Use relative path in git ignore

### DIFF
--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -145,7 +145,7 @@ function updateConfigs (args, newVersion) {
     }
     const configPath = path.resolve(process.cwd(), updater.filename)
     try {
-      if (dotgit.ignore(configPath)) return
+      if (dotgit.ignore(updater.filename)) return
       const stat = fs.lstatSync(configPath)
 
       if (!stat.isFile()) return


### PR DESCRIPTION
Copy of https://github.com/conventional-changelog/standard-version/pull/903, which fixes https://github.com/conventional-changelog/standard-version/issues/902