### PR TITLE
fix: fallback to git tag if no version in package file

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ module.exports = async function standardVersion (argv) {
   }
   try {
     let version
-    if (pkg) {
+    if (pkg && pkg.version) {
       version = pkg.version
     } else if (args.gitTagFallback) {
       version = await latestSemverTag(args.tagPrefix)


### PR DESCRIPTION
Copy of https://github.com/conventional-changelog/standard-version/pull/898 , fixes https://github.com/conventional-changelog/standard-version/issues/897

BEGIN_COMMIT_OVERRIDE
fix: Fallback to git tag if no version in package file
END_COMMIT_OVERRIDE