### PR TITLE
fix: continue with commit when commitAll is true

### DIFF
--- a/lib/lifecycles/commit.js
+++ b/lib/lifecycles/commit.js
@@ -46,7 +46,7 @@ async function execCommit (args, newVersion) {
   checkpoint(args, msg, paths)
 
   // nothing to do, exit without commit anything
-  if (args.skip.changelog && args.skip.bump && toAdd.length === 0) {
+  if (!args.commitAll && args.skip.changelog && args.skip.bump && toAdd.length === 0) {
     return
   }
 


### PR DESCRIPTION
This is a copy of https://github.com/conventional-changelog/standard-version/pull/666

BEGIN_COMMIT_OVERRIDE
fix: No longer skips the commit if changelog and bump are both skipped but `commitAll` is set
END_COMMIT_OVERRIDE