### PR TITLE
feat(updater): add Gradle support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ By default, `commit-and-tag-version` assumes you're working in a NodeJS based pr
 
 That said, if you find your self asking [How can I use commit-and-tag-version for additional metadata files, languages or version files?](#can-i-use-commit-and-tag-version-for-additional-metadata-files-languages-or-version-files) – these configuration options will help!
 
+### Gradle Support (Java/Kotlin)
+
+If you are using Gradle, then just point to your `build.gradle` file (or `build.gradle.kts` if using Kotlin DSL).
+
+```sh
+commit-and-tag-version --packageFiles build.gradle --bumpFiles build.gradle
+```
+
+
 ## Installing `commit-and-tag-version`
 
 ### As a local `npm run` script

--- a/lib/updaters/index.js
+++ b/lib/updaters/index.js
@@ -2,7 +2,8 @@ const path = require('path')
 const JSON_BUMP_FILES = require('../../defaults').bumpFiles
 const updatersByType = {
   json: require('./types/json'),
-  'plain-text': require('./types/plain-text')
+  'plain-text': require('./types/plain-text'),
+  gradle: require('./types/gradle')
 }
 const PLAIN_TEXT_BUMP_FILES = ['VERSION.txt', 'version.txt']
 
@@ -20,6 +21,9 @@ function getUpdaterByFilename (filename) {
   }
   if (PLAIN_TEXT_BUMP_FILES.includes(filename)) {
     return getUpdaterByType('plain-text')
+  }
+  if (/build.gradle/.test(filename)) {
+    return getUpdaterByType('gradle')
   }
   throw Error(
     `Unsupported file (${filename}) provided for bumping.\n Please specify the updater \`type\` or use a custom \`updater\`.`

--- a/lib/updaters/types/gradle.js
+++ b/lib/updaters/types/gradle.js
@@ -1,0 +1,17 @@
+const versionRegex = /^version\s+=\s+['"]([\d.]+)['"]/m
+
+module.exports.readVersion = function (contents) {
+  const matches = versionRegex.exec(contents)
+  if (matches === null) {
+    throw new Error('Failed to read the version field in your gradle file - is it present?')
+  }
+
+  return matches[1]
+}
+
+module.exports.writeVersion = function (contents, version) {
+  return contents.replace(versionRegex, () => {
+    return `version = "${version}"`
+  })
+}
+

--- a/lib/updaters/types/gradle.js
+++ b/lib/updaters/types/gradle.js
@@ -14,4 +14,3 @@ module.exports.writeVersion = function (contents, version) {
     return `version = "${version}"`
   })
 }
-

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -678,6 +678,21 @@ describe('commit-and-tag-version', function () {
     ).version.should.equal('6.4.0')
   })
 
+  it('bumps version in Gradle `build.gradle.kts` file', async function () {
+    const expected = fs.readFileSync('./test/mocks/build-6.4.0.gradle.kts', 'utf-8')
+    mock({
+      bump: 'minor',
+      fs: {
+        'build.gradle.kts': fs.readFileSync('./test/mocks/build-6.3.1.gradle.kts')
+      }
+    })
+    await exec({
+      packageFiles: [{ filename: 'build.gradle.kts', type: 'gradle' }],
+      bumpFiles: [{ filename: 'build.gradle.kts', type: 'gradle' }]
+    })
+    fs.readFileSync('build.gradle.kts', 'utf-8').should.equal(expected)
+  })
+
   it('bumps version # in npm-shrinkwrap.json', async function () {
     mock({
       bump: 'minor',

--- a/test/mocks/build-6.3.1.gradle.kts
+++ b/test/mocks/build-6.3.1.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    id("org.springframework.boot") version "2.4.6"
+    kotlin("jvm") version "1.4.31"
+    kotlin("plugin.spring") version "1.4.31"
+}
+
+version = "6.3.1"
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+

--- a/test/mocks/build-6.4.0.gradle.kts
+++ b/test/mocks/build-6.4.0.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    id("org.springframework.boot") version "2.4.6"
+    kotlin("jvm") version "1.4.31"
+    kotlin("plugin.spring") version "1.4.31"
+}
+
+version = "6.4.0"
+java.sourceCompatibility = JavaVersion.VERSION_1_8
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+


### PR DESCRIPTION
A simple change to bring Gradle (both Groovy and Kotlin DSL format will work) support by adding the corresponding updater.