### PR TITLE
feat: Expose release count option

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,27 @@ If you've already run `commit-and-tag-version` when creating your release, you m
 the version, by using `commit-and-tag-version --skip.bump`. By default, tagging with an already existing tag make `git` fails.
 You can add the `--tag-force` flag to make use of `-f` option when calling `git tag`, then the existing version tag will be replaced.
 
+### Generate changelogs for old releases
+
+Normally only the changelog for the last release will be generated and prepended to the `changelog.md`. If you want to generate changelogs for previous releases you can do so by setting the `releaseCount` option like described [here](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-core#releasecount).
+
+When setting releaseCount=0 the whole changelog gets regenerated and replaced.
+
+You can set the option either in the`.versionrc` file or inside `package.json` like below
+
+```json
+//.versionrc
+{
+  "releaseCount": 0
+}
+
+//package.json
+
+"commit-and-tag-version": {
+  "releaseCount": 0
+}
+```
+
 ### CLI Help
 
 ```sh

--- a/command.js
+++ b/command.js
@@ -73,6 +73,11 @@ const yargs = require('yargs')
     type: 'string',
     default: defaults.tagPrefix
   })
+  .option('release-count', {
+    describe: 'How many releases of changelog you want to generate. It counts from the upcoming release. Useful when you forgot to generate any previous changelog. Set to 0 to regenerate all.',
+    type: 'number',
+    default: defaults.releaseCount
+  })
   .option('tag-force', {
     describe: 'Allow tag replacement',
     type: 'boolean',

--- a/defaults.js
+++ b/defaults.js
@@ -8,6 +8,7 @@ const defaults = {
   commitAll: false,
   silent: false,
   tagPrefix: 'v',
+  releaseCount: 1,
   scripts: {},
   skip: {},
   dryRun: false,

--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -23,7 +23,7 @@ function outputChangelog (args, newVersion) {
     createIfMissing(args)
     const header = args.header
 
-    let oldContent = args.dryRun ? '' : fs.readFileSync(args.infile, 'utf-8')
+    let oldContent = args.dryRun || args.releaseCount === 0 ? '' : fs.readFileSync(args.infile, 'utf-8')
     const oldContentStart = oldContent.search(START_OF_LAST_RELEASE_PATTERN)
     // find the position of the last release and remove header:
     if (oldContentStart !== -1) {

--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -34,7 +34,8 @@ function outputChangelog (args, newVersion) {
     const changelogStream = conventionalChangelog({
       debug: args.verbose && console.info.bind(console, 'conventional-changelog'),
       preset: presetLoader(args),
-      tagPrefix: args.tagPrefix
+      tagPrefix: args.tagPrefix,
+      releaseCount: args.releaseCount
     }, context, { merges: null, path: args.path }, args.parserOpts, args.writerOpts)
       .on('error', function (err) {
         return reject(err)


### PR DESCRIPTION
Hey, thanks for the fork it offers really useful additions to standard-version! 

One feature that is missing for us is that we can't regenerate the complete changelog since the releaseCount option isn't passed through to conventional-changelog so I added it with this PR. If you have any feedback on it feel free to share.

Hope we can make it an addition to the package since also other people seem to miss it as well (Fixes #719)