### PR TITLE
fix: ensure git signatures are not present

### DIFF
--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -35,7 +35,7 @@ function outputChangelog (args, newVersion) {
       debug: args.verbose && console.info.bind(console, 'conventional-changelog'),
       preset: presetLoader(args),
       tagPrefix: args.tagPrefix
-    }, context, { merges: null, path: args.path }, args.parserOpts, args.writerOpts)
+    }, context, { merges: null, path: args.path, showSignature: false }, args.parserOpts, args.writerOpts)
       .on('error', function (err) {
         return reject(err)
       })


### PR DESCRIPTION
Currently an empty changeset is produced if the git configuration has `log.showSignature` set to `true`.  This change ensure we set it to `false` to allow commit header parsing to function correctly.

Further information can be found in
- https://github.com/conventional-changelog/conventional-changelog/issues/213
- https://github.com/conventional-changelog/conventional-changelog/pull/671

Signed-off-by: Adam Moss <2951486+adam-moss@users.noreply.github.com>