### PR TITLE
feat: support customize `npmPublishHint`

### DIFF
--- a/command.js
+++ b/command.js
@@ -121,6 +121,11 @@ const yargs = require('yargs')
     type: 'string',
     describe: 'Name of the package from which the tags will be extracted'
   })
+  .option('npmClient', {
+    type: 'string',
+    default: defaults.npmClient,
+    describe: 'Show publish hint with the specified npm client'
+  })
   .check((argv) => {
     if (typeof argv.scripts !== 'object' || Array.isArray(argv.scripts)) {
       throw Error('scripts must be an object')

--- a/command.js
+++ b/command.js
@@ -121,10 +121,10 @@ const yargs = require('yargs')
     type: 'string',
     describe: 'Name of the package from which the tags will be extracted'
   })
-  .option('npmClient', {
+  .option('npmPublishHint', {
     type: 'string',
-    default: defaults.npmClient,
-    describe: 'Show publish hint with the specified npm client'
+    default: defaults.npmPublishHint,
+    describe: 'Customized publishing hint'
   })
   .check((argv) => {
     if (typeof argv.scripts !== 'object' || Array.isArray(argv.scripts)) {

--- a/defaults.js
+++ b/defaults.js
@@ -15,7 +15,7 @@ const defaults = {
   tagForce: false,
   gitTagFallback: true,
   preset: require.resolve('conventional-changelog-conventionalcommits'),
-  npmClient: 'npm',
+  npmClient: 'npm'
 }
 
 /**

--- a/defaults.js
+++ b/defaults.js
@@ -15,7 +15,7 @@ const defaults = {
   tagForce: false,
   gitTagFallback: true,
   preset: require.resolve('conventional-changelog-conventionalcommits'),
-  npmClient: 'npm'
+  npmPublishHint: undefined
 }
 
 /**

--- a/defaults.js
+++ b/defaults.js
@@ -14,7 +14,8 @@ const defaults = {
   dryRun: false,
   tagForce: false,
   gitTagFallback: true,
-  preset: require.resolve('conventional-changelog-conventionalcommits')
+  preset: require.resolve('conventional-changelog-conventionalcommits'),
+  npmClient: 'npm',
 }
 
 /**

--- a/lib/detect-package-manager.js
+++ b/lib/detect-package-manager.js
@@ -1,0 +1,53 @@
+/**
+ * modified from <https://github.com/egoist/detect-package-manager/blob/main/src/index.ts>
+ * the original code is licensed under MIT
+ * modified to support only detecting lock file and not detecting global package manager
+ */
+
+const { promises: fs } = require('fs')
+const { resolve } = require('path')
+
+/**
+ * Check if a path exists
+ */
+async function pathExists (p) {
+  try {
+    await fs.access(p)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function getTypeofLockFile (cwd = '.') {
+  return Promise.all([
+    pathExists(resolve(cwd, 'yarn.lock')),
+    pathExists(resolve(cwd, 'package-lock.json')),
+    pathExists(resolve(cwd, 'pnpm-lock.yaml'))
+  ]).then(([isYarn, isNpm, isPnpm]) => {
+    let value = null
+
+    if (isYarn) {
+      value = 'yarn'
+    } else if (isPnpm) {
+      value = 'pnpm'
+    } else if (isNpm) {
+      value = 'npm'
+    }
+
+    return value
+  })
+}
+
+const detectPMByLockFile = async (cwd) => {
+  const type = await getTypeofLockFile(cwd)
+  if (type) {
+    return type
+  }
+
+  return 'npm'
+}
+
+module.exports = {
+  detectPMByLockFile
+}

--- a/lib/lifecycles/tag.js
+++ b/lib/lifecycles/tag.js
@@ -5,12 +5,19 @@ const figures = require('figures')
 const formatCommitMessage = require('../format-commit-message')
 const runExecFile = require('../run-execFile')
 const runLifecycleScript = require('../run-lifecycle-script')
+const { detectPMByLockFile } = require('../detect-package-manager')
 
 module.exports = async function (newVersion, pkgPrivate, args) {
   if (args.skip.tag) return
   await runLifecycleScript(args, 'pretag')
   await execTag(newVersion, pkgPrivate, args)
   await runLifecycleScript(args, 'posttag')
+}
+
+async function detectPublishHint () {
+  const npmClientName = await detectPMByLockFile()
+  const publishCommand = 'publish'
+  return `${npmClientName} ${publishCommand}`
 }
 
 async function execTag (newVersion, pkgPrivate, args) {
@@ -28,7 +35,8 @@ async function execTag (newVersion, pkgPrivate, args) {
   const currentBranch = await runExecFile('', 'git', ['rev-parse', '--abbrev-ref', 'HEAD'])
   let message = 'git push --follow-tags origin ' + currentBranch.trim()
   if (pkgPrivate !== true && bump.getUpdatedConfigs()['package.json']) {
-    message += ` && ${args.npmClient || 'npm'} publish`
+    const npmPublishHint = args.npmPublishHint || await detectPublishHint()
+    message += ` && ${npmPublishHint}`
     if (args.prerelease !== undefined) {
       if (args.prerelease === '') {
         message += ' --tag prerelease'

--- a/lib/lifecycles/tag.js
+++ b/lib/lifecycles/tag.js
@@ -28,7 +28,7 @@ async function execTag (newVersion, pkgPrivate, args) {
   const currentBranch = await runExecFile('', 'git', ['rev-parse', '--abbrev-ref', 'HEAD'])
   let message = 'git push --follow-tags origin ' + currentBranch.trim()
   if (pkgPrivate !== true && bump.getUpdatedConfigs()['package.json']) {
-    message += ' && npm publish'
+    message += ` && ${args.npmClient || 'npm'} publish`
     if (args.prerelease !== undefined) {
       if (args.prerelease === '') {
         message += ' --tag prerelease'

--- a/test/git.spec.js
+++ b/test/git.spec.js
@@ -397,6 +397,14 @@ describe('git', function () {
         .should.match(/npm publish/)
     })
 
+    it('can display publish hints with custom npm client name', async function () {
+      const flush = mock({ bump: 'patch' })
+      await exec('--npmClient yarn')
+      flush()
+        .stdout.join('')
+        .should.match(/yarn publish/)
+    })
+
     it('does not display `npm publish` if the package is private', async function () {
       writePackageJson('1.0.0', { private: true })
       const flush = mock({ bump: 'patch' })

--- a/test/git.spec.js
+++ b/test/git.spec.js
@@ -399,7 +399,7 @@ describe('git', function () {
 
     it('can display publish hints with custom npm client name', async function () {
       const flush = mock({ bump: 'patch' })
-      await exec('--npmClient yarn')
+      await exec('--npmPublishHint "yarn publish"')
       flush()
         .stdout.join('')
         .should.match(/yarn publish/)

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,0 +1,52 @@
+/* global describe it */
+
+const mockery = require('mockery')
+const { promises: fsp } = require('fs')
+require('chai').should()
+
+function mockNpm () {
+  mockery.enable({ warnOnUnregistered: false, useCleanCache: true })
+  let lockFile = ''
+
+  const fsMock = {
+    promises: {
+      access: async function (path) {
+        if (lockFile && path.endsWith(lockFile)) {
+          return true
+        }
+        await fsp.access(path)
+      }
+    }
+  }
+  mockery.registerMock('fs', fsMock)
+  return {
+    setLockFile (file) {
+      lockFile = file
+    }
+  }
+}
+
+describe('utils', () => {
+  it('detectPMByLockFile should work', async function () {
+    const { setLockFile } = mockNpm()
+    const { detectPMByLockFile } = require('../lib/detect-package-manager')
+
+    let pm = await detectPMByLockFile()
+    pm.should.equal('npm')
+
+    setLockFile('yarn.lock')
+    pm = await detectPMByLockFile()
+    pm.should.equal('yarn')
+
+    setLockFile('package-lock.json')
+    pm = await detectPMByLockFile()
+    pm.should.equal('npm')
+
+    setLockFile('pnpm-lock.yaml')
+    pm = await detectPMByLockFile()
+    pm.should.equal('pnpm')
+
+    mockery.deregisterAll()
+    mockery.disable()
+  })
+})


### PR DESCRIPTION
I'm using some npm client that not npm.

so I want it directly show `yarn publish`