### PR TITLE
chore(dep): add stringify-package to project source

### DIFF
--- a/lib/stringify-package.js
+++ b/lib/stringify-package.js
@@ -1,0 +1,18 @@
+'use strict'
+
+module.exports = stringifyPackage
+
+const DEFAULT_INDENT = 2
+const CRLF = '\r\n'
+const LF = '\n'
+
+function stringifyPackage (data, indent, newline) {
+  indent = indent || (indent === 0 ? 0 : DEFAULT_INDENT)
+  const json = JSON.stringify(data, null, indent)
+
+  if (newline === CRLF) {
+    return json.replace(/\n/g, CRLF) + CRLF
+  }
+
+  return json + LF
+}

--- a/lib/stringify-package.js
+++ b/lib/stringify-package.js
@@ -1,3 +1,21 @@
+/*
+Copyright npm, Inc
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+https://github.com/npm/stringify-package/blob/main/LICENSE
+*/
+
 'use strict'
 
 module.exports = stringifyPackage

--- a/lib/updaters/types/json.js
+++ b/lib/updaters/types/json.js
@@ -1,4 +1,4 @@
-const stringifyPackage = require('stringify-package')
+const stringifyPackage = require('../../stringify-package')
 const detectIndent = require('detect-indent')
 const detectNewline = require('detect-newline')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "find-up": "^5.0.0",
         "git-semver-tags": "^4.0.0",
         "semver": "^7.1.1",
-        "stringify-package": "^1.0.1",
         "yargs": "^17.0.0"
       },
       "bin": {
@@ -5258,11 +5257,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/stringify-package": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.1.tgz",
-      "integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg=="
-    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -9659,11 +9653,6 @@
         "define-properties": "^1.1.4",
         "es-abstract": "^1.19.5"
       }
-    },
-    "stringify-package": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.1.tgz",
-      "integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg=="
     },
     "strip-ansi": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "find-up": "^5.0.0",
     "git-semver-tags": "^4.0.0",
     "semver": "^7.1.1",
-    "stringify-package": "^1.0.1",
     "yargs": "^17.0.0"
   },
   "devDependencies": {

--- a/test/stringify-package.spec.js
+++ b/test/stringify-package.spec.js
@@ -1,0 +1,39 @@
+/* global describe it */
+
+'use strict'
+
+const stringifyPackage = require('../lib/stringify-package')
+
+require('chai').should()
+
+describe('stringifyPackage()', function () {
+  const dummy = { name: 'dummy' }
+
+  it('with no params uses \\n', function () {
+    stringifyPackage(dummy).should.match(/\n$/m)
+  })
+
+  it('uses \\n', function () {
+    stringifyPackage(dummy, 2, '\n').should.match(/\n$/m)
+  })
+
+  it('uses \\r\\n', function () {
+    stringifyPackage(dummy, 2, '\r\n').should.match(/\r\n$/m)
+  })
+
+  it('with no params uses 2-space indent', function () {
+    stringifyPackage(dummy).should.match(/^ {2}"name": "dummy"/m)
+  })
+
+  it('uses 2-space indent', function () {
+    stringifyPackage(dummy, 2, '\n').should.match(/^ {2}"name": "dummy"/m)
+  })
+
+  it('uses 4-space indent', function () {
+    stringifyPackage(dummy, 4, '\n').should.match(/^ {4}"name": "dummy"/m)
+  })
+
+  it('0 works', function () {
+    stringifyPackage(dummy, 0).split(/\r\n|\r|\n/).length.should.equal(2)
+  })
+})


### PR DESCRIPTION
Resolves https://github.com/absolute-version/commit-and-tag-version/issues/49

I considered replacing the `stringify-package` package with the `@npmcli/package-json` package as mentioned in https://github.com/absolute-version/commit-and-tag-version/issues/49#issuecomment-1360602538 but decided that it'd be less intrusive to this project's code to just copy over the code and tests over from the  `stringify-package` package instead (https://github.com/npm/stringify-package).

I also thought that adding `@npmcli/package-json` as a dependency a little overkill for this project's singular use case of updating the `package.json` file's version field.

