### PR TITLE
feat: allows to use semver strictly on versions less than 1.0.0

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -12,6 +12,7 @@ const defaults = {
   scripts: {},
   skip: {},
   dryRun: false,
+  strictSemver: false,
   tagForce: false,
   gitTagFallback: true,
   preset: require.resolve('conventional-changelog-conventionalcommits'),

--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -116,7 +116,7 @@ function bumpVersion (releaseAs, currentVersion, args) {
     } else {
       const presetOptions = presetLoader(args)
       if (typeof presetOptions === 'object') {
-        if (semver.lt(currentVersion, '1.0.0')) presetOptions.preMajor = true
+        if (semver.lt(currentVersion, '1.0.0') && !args.strictSemver) presetOptions.preMajor = true
       }
       conventionalRecommendedBump({
         debug: args.verbose && console.info.bind(console, 'conventional-recommended-bump'),


### PR DESCRIPTION
I re-pulled request this [PR](https://github.com/conventional-changelog/standard-version/pull/780) to the current repository.
standard-version for `feat` commit bump is a patch version, which is very unfriendly for feature fixes, expect commit-and-tag-version to provide a flag configured to strictly follow the semver specification.