### PR TITLE
fix(bump): also propagate the parserOpts from args to conventionalRecommendedBump

### DIFF
--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -124,7 +124,7 @@ function bumpVersion (releaseAs, currentVersion, args) {
         path: args.path,
         tagPrefix: args.tagPrefix,
         lernaPackage: args.lernaPackage
-      }, function (err, release) {
+      }, args.parserOpts, function (err, release) {
         if (err) return reject(err)
         else return resolve(release)
       })


### PR DESCRIPTION
Hi, to resolve the following behaviour (raised in the deprecated origin: https://github.com/conventional-changelog/standard-version/issues/690#issuecomment-1650769534) I've taken the idea and change of an already opened pull request https://github.com/conventional-changelog/standard-version/pull/821 (also from the deprecated origin) to fix it.

The bug thats observed is that when using the `parserOpts` and setting `headerPattern` to for example match the Azure DevOps prefix e.g using this regex `"(?:\\(Merged PR \\d+: \\))?([a-zA-Z]+)(?:\\(([\\w$\\.\\-*\\s]*)\\))?\\!?:(.*)"` features committed with e.g. "feat: abc" and then merged as "Merged PR 0: feat: abc" are classified correctly when writing them to the changelog but the bump only increases the patch. Thats the default bump. The bump uses the default config and the parserOpts seem not to be propagated.

Any reason or concerns about this fix? :)