### PR TITLE
Allow overwriting whatBump of presets

### DIFF
--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -195,6 +195,7 @@ function bumpVersion(releaseAs, currentVersion, args) {
           preset: presetOptions,
           path: args.path,
           tagPrefix: args.tagPrefix,
+          whatBump: args.whatBump,
           lernaPackage: args.lernaPackage,
         },
         args.parserOpts,


### PR DESCRIPTION
The [implementation](https://github.com/conventional-changelog/conventional-changelog/blob/a149b76765c36705bde56eaf72c04e19a6f738cb/packages/conventional-recommended-bump/index.js#L27) of `conventional-recommended-bump` allows to pass a `whatBump` function which isn't the result of preset loading.

I added a simple passthrough from args to the `conventionalRecommendedBump` call to allow easily overwriting the preset defined `whatBump`.

### Why was this added

Since the release of following [changes](https://github.com/absolute-version/commit-and-tag-version/pull/89) in [v11.2.3](https://github.com/absolute-version/commit-and-tag-version/releases/tag/v11.2.3) I got an issue with my use-case for using the library.

I'm using custom notes / footers in my commit messages using the tool. This should follow the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0)
> footers other than BREAKING CHANGE: <description> may be provided and follow a convention similar to [git trailer format](https://git-scm.com/docs/git-interpret-trailers).

Unfortunately the basic whatBump function interprets [every single commit containing a footer as BREAKING CHANGE](https://github.com/conventional-changelog/conventional-changelog/blob/a149b76765c36705bde56eaf72c04e19a6f738cb/packages/conventional-changelog-conventionalcommits/conventionalRecommendedBump.js#L17). 

Generally the logic of `conventional-changelog-conventionalcommits` should be updated, but allowing for overwriting the function of a preset gives a nice flexibility for all presets and customized applications of the library.