### PR TITLE
fix: Add debug messages for exclusions during bump lifecycle

### DIFF
--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -223,13 +223,13 @@ function updateConfigs(args, newVersion) {
     const configPath = path.resolve(process.cwd(), updater.filename);
     try {
       if (dotgit.ignore(updater.filename)) {
-        console.debug(updater.filename + ' is ignored in Git')
+        console.debug(updater.filename + ' is ignored in Git');
         return;
       }
       const stat = fs.lstatSync(configPath);
 
       if (!stat.isFile()) {
-        console.debug(updater.filename + ' is not a file')
+        console.debug(updater.filename + ' is not a file');
         return;
       }
       const contents = fs.readFileSync(configPath, 'utf8');

--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -222,10 +222,16 @@ function updateConfigs(args, newVersion) {
     }
     const configPath = path.resolve(process.cwd(), updater.filename);
     try {
-      if (dotgit.ignore(updater.filename)) return;
+      if (dotgit.ignore(updater.filename)) {
+        console.debug(updater.filename + ' is ignored in Git')
+        return;
+      }
       const stat = fs.lstatSync(configPath);
 
-      if (!stat.isFile()) return;
+      if (!stat.isFile()) {
+        console.debug(updater.filename + ' is not a file')
+        return;
+      }
       const contents = fs.readFileSync(configPath, 'utf8');
       const newContents = updater.updater.writeVersion(contents, newVersion);
       const realNewVersion = updater.updater.readVersion(newContents);

--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -223,13 +223,17 @@ function updateConfigs(args, newVersion) {
     const configPath = path.resolve(process.cwd(), updater.filename);
     try {
       if (dotgit.ignore(updater.filename)) {
-        console.debug(updater.filename + ' is ignored in Git');
+        console.debug(
+          `Not updating file '${updater.filename}', as it is ignored in Git`,
+        );
         return;
       }
       const stat = fs.lstatSync(configPath);
 
       if (!stat.isFile()) {
-        console.debug(updater.filename + ' is not a file');
+        console.debug(
+          `Not updating '${updater.filename}', as it is not a file`,
+        );
         return;
       }
       const contents = fs.readFileSync(configPath, 'utf8');


### PR DESCRIPTION
Code has been modified to include debug messages in the bump lifecycle. When a filename is ignored by Git or is not a file, the program will now log a debug-level message.