### PR TITLE
feat(updater): add YAML support (#33, #748)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ This is going to read and update only the `<Version>` tag in the file.
 commit-and-tag-version --packageFiles <YOUR-PROJECT-NAME>.csproj --bumpFiles <YOUR-PROJECT-NAME>.csproj
 ```
 
+### YAML Support
+
+If you are using YAML files.
+This is going to read and update only the `version:` tag in the file.
+
+```sh
+commit-and-tag-version --packageFiles file.yaml --bumpFiles file.yaml
+```
+
 ## Installing `commit-and-tag-version`
 
 ### As a local `npm run` script

--- a/lib/updaters/index.js
+++ b/lib/updaters/index.js
@@ -6,6 +6,7 @@ const updatersByType = {
   maven: require('./types/maven'),
   gradle: require('./types/gradle'),
   csproj: require('./types/csproj'),
+  yaml: require('./types/yaml'),
 };
 const PLAIN_TEXT_BUMP_FILES = ['VERSION.txt', 'version.txt'];
 
@@ -32,6 +33,9 @@ function getUpdaterByFilename(filename) {
   }
   if (filename.endsWith('.csproj')) {
     return getUpdaterByType('csproj');
+  }
+  if (/\.ya?ml$/.test(filename)) {
+    return getUpdaterByType('yaml');
   }
   throw Error(
     `Unsupported file (${filename}) provided for bumping.\n Please specify the updater \`type\` or use a custom \`updater\`.`,

--- a/lib/updaters/types/yaml.js
+++ b/lib/updaters/types/yaml.js
@@ -1,0 +1,15 @@
+const yaml = require('yaml');
+const detectNewline = require('detect-newline');
+
+module.exports.readVersion = function (contents) {
+  return yaml.parse(contents).version;
+};
+
+module.exports.writeVersion = function (contents, version) {
+  const newline = detectNewline(contents);
+  const document = yaml.parseDocument(contents);
+
+  document.set('version', version);
+
+  return document.toString().replace(/\r?\n/g, newline);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "jsdom": "^23.2.0",
         "semver": "^7.5.4",
         "w3c-xmlserializer": "^5.0.0",
+        "yaml": "^2.4.1",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -8491,6 +8492,17 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.1.tgz",
+      "integrity": "sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "jsdom": "^23.2.0",
     "semver": "^7.5.4",
     "w3c-xmlserializer": "^5.0.0",
+    "yaml": "^2.4.1",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -1365,6 +1365,78 @@ describe('cli', function () {
       verifyPackageVersion({ writeFileSyncSpy, expectedVersion: '1.1.0' });
     });
 
+    it('bumps version in Dart `pubspec.yaml` file', async function () {
+      const expected = fs.readFileSync(
+        './test/mocks/pubspec-6.4.0.yaml',
+        'utf-8',
+      );
+
+      const filename = 'pubspec.yaml';
+      mock({
+        bump: 'minor',
+        realTestFiles: [
+          {
+            filename,
+            path: './test/mocks/pubspec-6.3.1.yaml',
+          },
+        ],
+      });
+
+      await exec({
+        packageFiles: [{ filename, type: 'yaml' }],
+        bumpFiles: [{ filename, type: 'yaml' }],
+      });
+
+      // filePath is the first arg passed to writeFileSync
+      const packageJsonWriteFileSynchCall = findWriteFileCallForPath({
+        writeFileSyncSpy,
+        filename,
+      });
+
+      if (!packageJsonWriteFileSynchCall) {
+        throw new Error(`writeFileSynch not invoked with path ${filename}`);
+      }
+
+      const calledWithContentStr = packageJsonWriteFileSynchCall[1];
+      expect(calledWithContentStr).toEqual(expected);
+    });
+
+    it('bumps version in Dart `pubspec.yaml` file with CRLF line endings', async function () {
+      const expected = fs.readFileSync(
+        './test/mocks/pubspec-6.4.0-crlf.yaml',
+        'utf-8',
+      );
+
+      const filename = 'pubspec.yaml';
+      mock({
+        bump: 'minor',
+        realTestFiles: [
+          {
+            filename,
+            path: './test/mocks/pubspec-6.3.1-crlf.yaml',
+          },
+        ],
+      });
+
+      await exec({
+        packageFiles: [{ filename, type: 'yaml' }],
+        bumpFiles: [{ filename, type: 'yaml' }],
+      });
+
+      // filePath is the first arg passed to writeFileSync
+      const packageJsonWriteFileSynchCall = findWriteFileCallForPath({
+        writeFileSyncSpy,
+        filename,
+      });
+
+      if (!packageJsonWriteFileSynchCall) {
+        throw new Error(`writeFileSynch not invoked with path ${filename}`);
+      }
+
+      const calledWithContentStr = packageJsonWriteFileSynchCall[1];
+      expect(calledWithContentStr).toEqual(expected);
+    });
+
     describe('skip', function () {
       it('allows bump and changelog generation to be skipped', async function () {
         const changelogContent = 'legacy header format<a name="1.0.0">\n';

--- a/test/mocks/pubspec-6.3.1-crlf.yaml
+++ b/test/mocks/pubspec-6.3.1-crlf.yaml
@@ -1,0 +1,33 @@
+# This is a comment that should be preserved
+name: mock
+description: "A mock YAML file"
+version: 6.3.1
+
+environment:
+  dart: ">=3.2.6 <4.0.0"
+  flutter: ">=1.17.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+# For information on the generic Dart part of this file, see the
+# following page: https://dart.dev/tools/pub/pubspec
+
+# The following section is specific to Flutter packages.
+flutter:
+  uses-material-design: true
+  generate: true
+
+  # More comments here nested under one entry
+  #
+  # These comments should also be preserved.
+
+  # Another comment block, separated from the first one
+  assets:
+    - assets/icons/
+    - assets/images/

--- a/test/mocks/pubspec-6.3.1.yaml
+++ b/test/mocks/pubspec-6.3.1.yaml
@@ -1,0 +1,33 @@
+# This is a comment that should be preserved
+name: mock
+description: "A mock YAML file"
+version: 6.3.1
+
+environment:
+  dart: ">=3.2.6 <4.0.0"
+  flutter: ">=1.17.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+# For information on the generic Dart part of this file, see the
+# following page: https://dart.dev/tools/pub/pubspec
+
+# The following section is specific to Flutter packages.
+flutter:
+  uses-material-design: true
+  generate: true
+
+  # More comments here nested under one entry
+  #
+  # These comments should also be preserved.
+
+  # Another comment block, separated from the first one
+  assets:
+    - assets/icons/
+    - assets/images/

--- a/test/mocks/pubspec-6.4.0-crlf.yaml
+++ b/test/mocks/pubspec-6.4.0-crlf.yaml
@@ -1,0 +1,33 @@
+# This is a comment that should be preserved
+name: mock
+description: "A mock YAML file"
+version: 6.4.0
+
+environment:
+  dart: ">=3.2.6 <4.0.0"
+  flutter: ">=1.17.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+# For information on the generic Dart part of this file, see the
+# following page: https://dart.dev/tools/pub/pubspec
+
+# The following section is specific to Flutter packages.
+flutter:
+  uses-material-design: true
+  generate: true
+
+  # More comments here nested under one entry
+  #
+  # These comments should also be preserved.
+
+  # Another comment block, separated from the first one
+  assets:
+    - assets/icons/
+    - assets/images/

--- a/test/mocks/pubspec-6.4.0.yaml
+++ b/test/mocks/pubspec-6.4.0.yaml
@@ -1,0 +1,33 @@
+# This is a comment that should be preserved
+name: mock
+description: "A mock YAML file"
+version: 6.4.0
+
+environment:
+  dart: ">=3.2.6 <4.0.0"
+  flutter: ">=1.17.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+# For information on the generic Dart part of this file, see the
+# following page: https://dart.dev/tools/pub/pubspec
+
+# The following section is specific to Flutter packages.
+flutter:
+  uses-material-design: true
+  generate: true
+
+  # More comments here nested under one entry
+  #
+  # These comments should also be preserved.
+
+  # Another comment block, separated from the first one
+  assets:
+    - assets/icons/
+    - assets/images/


### PR DESCRIPTION
Adding support for YAML files. Based on #748. Geared towards Dart/Flutter `pubspec.yaml` files, but will work with any YAML file using root level `version` key.