### PR TITLE
fix: Raise the 'openapi'-updater to a higher order of precedence above the 'yaml'-updater

### DIFF
--- a/lib/updaters/index.js
+++ b/lib/updaters/index.js
@@ -35,11 +35,11 @@ function getUpdaterByFilename(filename) {
   if (filename.endsWith('.csproj')) {
     return getUpdaterByType('csproj');
   }
-  if (/\.ya?ml$/.test(filename)) {
-    return getUpdaterByType('yaml');
-  }
   if (/openapi.yaml/.test(filename)) {
     return getUpdaterByType('openapi');
+  }
+  if (/\.ya?ml$/.test(filename)) {
+    return getUpdaterByType('yaml');
   }
   throw Error(
     `Unsupported file (${filename}) provided for bumping.\n Please specify the updater \`type\` or use a custom \`updater\`.`,


### PR DESCRIPTION
# The problem

This PR addresses the issue where `openapi.yaml` files are incorrectly bumped with the "yaml"-updater instead of the "openapi"-updater.

# The fix

The fix applied here is to raise the "openapi"-updater to have a higher order of precedence than the "yaml"-updater.
