### PR TITLE
fix(deps): update dependency conventional-changelog to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "chalk": "^2.4.2",
-        "conventional-changelog": "3.1.25",
+        "conventional-changelog": "4.0.0",
         "conventional-changelog-config-spec": "2.1.0",
         "conventional-changelog-conventionalcommits": "6.1.0",
         "conventional-recommended-bump": "7.0.1",
@@ -659,6 +659,8 @@
     },
     "node_modules/@hutson/parse-repository-url": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz",
+      "integrity": "sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=6.9.0"
@@ -1714,6 +1716,8 @@
     },
     "node_modules/add-stream": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
+      "integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
       "license": "MIT"
     },
     "node_modules/agent-base": {
@@ -2288,6 +2292,8 @@
     },
     "node_modules/cliui": {
       "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -2357,54 +2363,55 @@
       }
     },
     "node_modules/conventional-changelog": {
-      "version": "3.1.25",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-4.0.0.tgz",
+      "integrity": "sha512-JbZjwE1PzxQCvm+HUTIr+pbSekS8qdOZzMakdFyPtdkEWwFvwEJYONzjgMm0txCb2yBcIcfKDmg8xtCKTdecNQ==",
       "license": "MIT",
       "dependencies": {
-        "conventional-changelog-angular": "^5.0.12",
-        "conventional-changelog-atom": "^2.0.8",
-        "conventional-changelog-codemirror": "^2.0.8",
-        "conventional-changelog-conventionalcommits": "^4.5.0",
-        "conventional-changelog-core": "^4.2.1",
-        "conventional-changelog-ember": "^2.0.9",
-        "conventional-changelog-eslint": "^3.0.9",
-        "conventional-changelog-express": "^2.0.6",
-        "conventional-changelog-jquery": "^3.0.11",
-        "conventional-changelog-jshint": "^2.0.9",
-        "conventional-changelog-preset-loader": "^2.3.4"
+        "conventional-changelog-angular": "^6.0.0",
+        "conventional-changelog-atom": "^3.0.0",
+        "conventional-changelog-codemirror": "^3.0.0",
+        "conventional-changelog-conventionalcommits": "^6.0.0",
+        "conventional-changelog-core": "^5.0.0",
+        "conventional-changelog-ember": "^3.0.0",
+        "conventional-changelog-eslint": "^4.0.0",
+        "conventional-changelog-express": "^3.0.0",
+        "conventional-changelog-jquery": "^4.0.0",
+        "conventional-changelog-jshint": "^3.0.0",
+        "conventional-changelog-preset-loader": "^3.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/conventional-changelog-angular": {
-      "version": "5.0.13",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-6.0.0.tgz",
+      "integrity": "sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==",
       "license": "ISC",
       "dependencies": {
-        "compare-func": "^2.0.0",
-        "q": "^1.5.1"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/conventional-changelog-atom": {
-      "version": "2.0.8",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-3.0.0.tgz",
+      "integrity": "sha512-pnN5bWpH+iTUWU3FaYdw5lJmfWeqSyrUkG+wyHBI9tC1dLNnHkbAOg1SzTQ7zBqiFrfo55h40VsGXWMdopwc5g==",
       "license": "ISC",
-      "dependencies": {
-        "q": "^1.5.1"
-      },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/conventional-changelog-codemirror": {
-      "version": "2.0.8",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-3.0.0.tgz",
+      "integrity": "sha512-wzchZt9HEaAZrenZAUUHMCFcuYzGoZ1wG/kTRMICxsnW5AXohYMRxnyecP9ob42Gvn5TilhC0q66AtTPRSNMfw==",
       "license": "ISC",
-      "dependencies": {
-        "q": "^1.5.1"
-      },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/conventional-changelog-config-spec": {
@@ -2422,174 +2429,134 @@
       }
     },
     "node_modules/conventional-changelog-core": {
-      "version": "4.2.4",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-5.0.2.tgz",
+      "integrity": "sha512-RhQOcDweXNWvlRwUDCpaqXzbZemKPKncCWZG50Alth72WITVd6nhVk9MJ6w1k9PFNBcZ3YwkdkChE+8+ZwtUug==",
       "license": "MIT",
       "dependencies": {
         "add-stream": "^1.0.0",
-        "conventional-changelog-writer": "^5.0.0",
-        "conventional-commits-parser": "^3.2.0",
-        "dateformat": "^3.0.0",
-        "get-pkg-repo": "^4.0.0",
-        "git-raw-commits": "^2.0.8",
+        "conventional-changelog-writer": "^6.0.0",
+        "conventional-commits-parser": "^4.0.0",
+        "dateformat": "^3.0.3",
+        "get-pkg-repo": "^4.2.1",
+        "git-raw-commits": "^3.0.0",
         "git-remote-origin-url": "^2.0.0",
-        "git-semver-tags": "^4.1.1",
-        "lodash": "^4.17.15",
-        "normalize-package-data": "^3.0.0",
-        "q": "^1.5.1",
+        "git-semver-tags": "^5.0.0",
+        "normalize-package-data": "^3.0.3",
         "read-pkg": "^3.0.0",
-        "read-pkg-up": "^3.0.0",
-        "through2": "^4.0.0"
+        "read-pkg-up": "^3.0.0"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/git-semver-tags": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "meow": "^8.0.0",
-        "semver": "^6.0.0"
-      },
-      "bin": {
-        "git-semver-tags": "cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/semver": {
-      "version": "6.3.1",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
+        "node": ">=14"
       }
     },
     "node_modules/conventional-changelog-ember": {
-      "version": "2.0.9",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-3.0.0.tgz",
+      "integrity": "sha512-7PYthCoSxIS98vWhVcSphMYM322OxptpKAuHYdVspryI0ooLDehRXWeRWgN+zWSBXKl/pwdgAg8IpLNSM1/61A==",
       "license": "ISC",
-      "dependencies": {
-        "q": "^1.5.1"
-      },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/conventional-changelog-eslint": {
-      "version": "3.0.9",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-4.0.0.tgz",
+      "integrity": "sha512-nEZ9byP89hIU0dMx37JXQkE1IpMmqKtsaR24X7aM3L6Yy/uAtbb+ogqthuNYJkeO1HyvK7JsX84z8649hvp43Q==",
       "license": "ISC",
-      "dependencies": {
-        "q": "^1.5.1"
-      },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/conventional-changelog-express": {
-      "version": "2.0.6",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-3.0.0.tgz",
+      "integrity": "sha512-HqxihpUMfIuxvlPvC6HltA4ZktQEUan/v3XQ77+/zbu8No/fqK3rxSZaYeHYant7zRxQNIIli7S+qLS9tX9zQA==",
       "license": "ISC",
-      "dependencies": {
-        "q": "^1.5.1"
-      },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/conventional-changelog-jquery": {
-      "version": "3.0.11",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-4.0.0.tgz",
+      "integrity": "sha512-TTIN5CyzRMf8PUwyy4IOLmLV2DFmPtasKN+x7EQKzwSX8086XYwo+NeaeA3VUT8bvKaIy5z/JoWUvi7huUOgaw==",
       "license": "ISC",
-      "dependencies": {
-        "q": "^1.5.1"
-      },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/conventional-changelog-jshint": {
-      "version": "2.0.9",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-3.0.0.tgz",
+      "integrity": "sha512-bQof4byF4q+n+dwFRkJ/jGf9dCNUv4/kCDcjeCizBvfF81TeimPZBB6fT4HYbXgxxfxWXNl/i+J6T0nI4by6DA==",
       "license": "ISC",
       "dependencies": {
-        "compare-func": "^2.0.0",
-        "q": "^1.5.1"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/conventional-changelog-preset-loader": {
-      "version": "2.3.4",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-3.0.0.tgz",
+      "integrity": "sha512-qy9XbdSLmVnwnvzEisjxdDiLA4OmV3o8db+Zdg4WiFw14fP3B6XNz98X0swPPpkTd/pc1K7+adKgEDM1JCUMiA==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/conventional-changelog-writer": {
-      "version": "5.0.1",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-6.0.1.tgz",
+      "integrity": "sha512-359t9aHorPw+U+nHzUXHS5ZnPBOizRxfQsWT5ZDHBfvfxQOAik+yfuhKXG66CN5LEWPpMNnIMHUTCKeYNprvHQ==",
       "license": "MIT",
       "dependencies": {
-        "conventional-commits-filter": "^2.0.7",
-        "dateformat": "^3.0.0",
+        "conventional-commits-filter": "^3.0.0",
+        "dateformat": "^3.0.3",
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
-        "meow": "^8.0.0",
-        "semver": "^6.0.0",
-        "split": "^1.0.0",
-        "through2": "^4.0.0"
+        "meow": "^8.1.2",
+        "semver": "^7.0.0",
+        "split": "^1.0.1"
       },
       "bin": {
         "conventional-changelog-writer": "cli.js"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-changelog-writer/node_modules/semver": {
-      "version": "6.3.1",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/conventional-changelog/node_modules/conventional-changelog-conventionalcommits": {
-      "version": "4.6.3",
-      "license": "ISC",
-      "dependencies": {
-        "compare-func": "^2.0.0",
-        "lodash": "^4.17.15",
-        "q": "^1.5.1"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/conventional-commits-filter": {
-      "version": "2.0.7",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-3.0.0.tgz",
+      "integrity": "sha512-1ymej8b5LouPx9Ox0Dw/qAO2dVdfpRFq28e5Y0jJEU8ZrLdy0vOSkkIInwmxErFGhg6SALro60ZrwYFVTUDo4Q==",
       "license": "MIT",
       "dependencies": {
         "lodash.ismatch": "^4.4.0",
-        "modify-values": "^1.0.0"
+        "modify-values": "^1.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/conventional-commits-parser": {
-      "version": "3.2.4",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-4.0.0.tgz",
+      "integrity": "sha512-WRv5j1FsVM5FISJkoYMR6tPk07fkKT0UodruX4je86V4owk451yjXAKzKAPOs9l7y59E2viHUS9eQ+dfUA9NSg==",
       "license": "MIT",
       "dependencies": {
         "is-text-path": "^1.0.1",
-        "JSONStream": "^1.0.4",
-        "lodash": "^4.17.15",
-        "meow": "^8.0.0",
-        "split2": "^3.0.0",
-        "through2": "^4.0.0"
+        "JSONStream": "^1.3.5",
+        "meow": "^8.1.2",
+        "split2": "^3.2.2"
       },
       "bin": {
         "conventional-commits-parser": "cli.js"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/conventional-recommended-bump": {
@@ -2611,55 +2578,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/conventional-recommended-bump/node_modules/conventional-changelog-preset-loader": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/conventional-commits-filter": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "lodash.ismatch": "^4.4.0",
-        "modify-values": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/conventional-commits-parser": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-text-path": "^1.0.1",
-        "JSONStream": "^1.3.5",
-        "meow": "^8.1.2",
-        "split2": "^3.2.2"
-      },
-      "bin": {
-        "conventional-commits-parser": "cli.js"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/git-raw-commits": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "dargs": "^7.0.0",
-        "meow": "^8.1.2",
-        "split2": "^3.2.2"
-      },
-      "bin": {
-        "git-raw-commits": "cli.js"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "1.8.0",
       "dev": true,
@@ -2670,6 +2588,8 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/create-jest": {
@@ -2801,6 +2721,8 @@
     },
     "node_modules/dateformat": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -3943,6 +3865,8 @@
     },
     "node_modules/get-pkg-repo": {
       "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-4.2.1.tgz",
+      "integrity": "sha512-2+QbHjFRfGB74v/pYWjd5OhU3TDIC2Gv/YKUTk/tCvAz0pkn/Mz6P3uByuBimLOcPvN2jYdScl3xGFSrx0jEcA==",
       "license": "MIT",
       "dependencies": {
         "@hutson/parse-repository-url": "^3.0.0",
@@ -3957,36 +3881,10 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/get-pkg-repo/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/get-pkg-repo/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/get-pkg-repo/node_modules/through2": {
-      "version": "2.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
-    },
     "node_modules/get-pkg-repo/node_modules/yargs": {
       "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^7.0.2",
@@ -4028,24 +3926,26 @@
       }
     },
     "node_modules/git-raw-commits": {
-      "version": "2.0.11",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-3.0.0.tgz",
+      "integrity": "sha512-b5OHmZ3vAgGrDn/X0kS+9qCfNKWe4K/jFnhwzVWWg0/k5eLa3060tZShrRg8Dja5kPc+YjS0Gc6y7cRr44Lpjw==",
       "license": "MIT",
       "dependencies": {
         "dargs": "^7.0.0",
-        "lodash": "^4.17.15",
-        "meow": "^8.0.0",
-        "split2": "^3.0.0",
-        "through2": "^4.0.0"
+        "meow": "^8.1.2",
+        "split2": "^3.2.2"
       },
       "bin": {
         "git-raw-commits": "cli.js"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/git-remote-origin-url": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
+      "integrity": "sha512-eU+GGrZgccNJcsDH5LkXR3PB9M958hxc7sbA8DFJjrv9j4L2P/eZfKhM+QD6wyzpiv+b1BpK0XrYCxkovtjSLw==",
       "license": "MIT",
       "dependencies": {
         "gitconfiglocal": "^1.0.0",
@@ -4078,6 +3978,8 @@
     },
     "node_modules/gitconfiglocal": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
+      "integrity": "sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ==",
       "license": "BSD",
       "dependencies": {
         "ini": "^1.3.2"
@@ -4183,11 +4085,13 @@
       "license": "MIT"
     },
     "node_modules/handlebars": {
-      "version": "4.7.7",
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
+        "neo-async": "^2.6.2",
         "source-map": "^0.6.1",
         "wordwrap": "^1.0.0"
       },
@@ -4422,6 +4326,8 @@
     },
     "node_modules/ini": {
       "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -4721,6 +4627,8 @@
     },
     "node_modules/isarray": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -6323,6 +6231,8 @@
     },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
@@ -6343,6 +6253,8 @@
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "license": "ISC"
     },
     "node_modules/json5": {
@@ -6418,6 +6330,8 @@
     },
     "node_modules/load-json-file": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.2",
@@ -6431,6 +6345,8 @@
     },
     "node_modules/load-json-file/node_modules/pify": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -6438,6 +6354,8 @@
     },
     "node_modules/load-json-file/node_modules/strip-bom": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -6455,10 +6373,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "license": "MIT"
     },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
@@ -6778,6 +6692,8 @@
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
     },
     "node_modules/node-int64": {
@@ -6989,6 +6905,8 @@
     },
     "node_modules/parse-json": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
       "license": "MIT",
       "dependencies": {
         "error-ex": "^1.3.1",
@@ -7038,6 +6956,8 @@
     },
     "node_modules/path-type": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "license": "MIT",
       "dependencies": {
         "pify": "^3.0.0"
@@ -7048,6 +6968,8 @@
     },
     "node_modules/path-type/node_modules/pify": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -7071,6 +6993,8 @@
     },
     "node_modules/pify": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7192,6 +7116,8 @@
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
     "node_modules/prompts": {
@@ -7233,14 +7159,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/q": {
-      "version": "1.5.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
-      }
-    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -7279,6 +7197,8 @@
     },
     "node_modules/read-pkg": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
       "license": "MIT",
       "dependencies": {
         "load-json-file": "^4.0.0",
@@ -7291,6 +7211,8 @@
     },
     "node_modules/read-pkg-up": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+      "integrity": "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==",
       "license": "MIT",
       "dependencies": {
         "find-up": "^2.0.0",
@@ -7302,6 +7224,8 @@
     },
     "node_modules/read-pkg-up/node_modules/find-up": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
       "license": "MIT",
       "dependencies": {
         "locate-path": "^2.0.0"
@@ -7312,6 +7236,8 @@
     },
     "node_modules/read-pkg-up/node_modules/locate-path": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
       "license": "MIT",
       "dependencies": {
         "p-locate": "^2.0.0",
@@ -7323,6 +7249,8 @@
     },
     "node_modules/read-pkg-up/node_modules/p-limit": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "license": "MIT",
       "dependencies": {
         "p-try": "^1.0.0"
@@ -7333,6 +7261,8 @@
     },
     "node_modules/read-pkg-up/node_modules/p-locate": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
       "license": "MIT",
       "dependencies": {
         "p-limit": "^1.1.0"
@@ -7343,6 +7273,8 @@
     },
     "node_modules/read-pkg-up/node_modules/p-try": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -7350,6 +7282,8 @@
     },
     "node_modules/read-pkg-up/node_modules/path-exists": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -7357,10 +7291,14 @@
     },
     "node_modules/read-pkg/node_modules/hosted-git-info": {
       "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "license": "ISC"
     },
     "node_modules/read-pkg/node_modules/normalize-package-data": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^2.1.4",
@@ -7371,6 +7309,8 @@
     },
     "node_modules/read-pkg/node_modules/semver": {
       "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -7753,6 +7693,8 @@
     },
     "node_modules/split": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "license": "MIT",
       "dependencies": {
         "through": "2"
@@ -7985,10 +7927,37 @@
       "license": "MIT"
     },
     "node_modules/through2": {
-      "version": "4.0.2",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "license": "MIT",
       "dependencies": {
-        "readable-stream": "3"
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/tmpl": {
@@ -8209,7 +8178,9 @@
       }
     },
     "node_modules/uglify-js": {
-      "version": "3.15.5",
+      "version": "3.19.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.2.tgz",
+      "integrity": "sha512-S8KA6DDI47nQXJSi2ctQ629YzwOVs+bQML6DAtvy0wgNdpi+0ySpQK0g2pxBq2xfF2z3YCscu7NNA8nXT9PlIQ==",
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
@@ -8402,6 +8373,8 @@
     },
     "node_modules/wordwrap": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {
@@ -8487,6 +8460,8 @@
     },
     "node_modules/xtend": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.4"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/absolute-version/commit-and-tag-version#readme",
   "dependencies": {
     "chalk": "^2.4.2",
-    "conventional-changelog": "3.1.25",
+    "conventional-changelog": "4.0.0",
     "conventional-changelog-config-spec": "2.1.0",
     "conventional-changelog-conventionalcommits": "6.1.0",
     "conventional-recommended-bump": "7.0.1",


### PR DESCRIPTION
Updates conventional-changelog to v4.0.0 to get rid of a lot of outdated dependencies and their warnings, mostly `q` from all the presets?

**Why v4.0.0?**
By process of elimination:
- v6 uses ESM :x:
- v5 uses `git-raw-commits` v4, which uses dynamic imports, which causes jest to fail with default config (see below) :x:
- v4 passes all tests locally ✅ 

---

**The v5 issue**
When running tests, we get the following failure, because `git-raw-commits` v4 uses a dynamic import:

```
TypeError: A dynamic import callback was invoked without --experimental-vm-modules
```

This failure appears to be an issue with Jest only, and could be fixed by running tests with an experimental node flag.
See: https://jestjs.io/docs/ecmascript-modules