### PR TITLE
fix: ignore other prerelease tags when finding latest tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ module.exports = async function standardVersion(argv) {
     if (pkg && pkg.version) {
       version = pkg.version;
     } else if (args.gitTagFallback) {
-      version = await latestSemverTag(args.tagPrefix);
+      version = await latestSemverTag(args);
     } else {
       throw new Error('no package file found');
     }

--- a/lib/latest-semver-tag.js
+++ b/lib/latest-semver-tag.js
@@ -1,13 +1,28 @@
 const gitSemverTags = require('git-semver-tags');
 const semver = require('semver');
 
-module.exports = function (tagPrefix = undefined) {
+module.exports = function ({ tagPrefix, prerelease }) {
   return new Promise((resolve, reject) => {
     gitSemverTags({ tagPrefix }, function (err, tags) {
       if (err) return reject(err);
       else if (!tags.length) return resolve('1.0.0');
       // Respect tagPrefix
       tags = tags.map((tag) => tag.replace(new RegExp('^' + tagPrefix), ''));
+      if (prerelease) {
+        // ignore any other prelease tags
+        tags = tags.filter((tag) => {
+          if (!semver.valid(tag)) return false;
+          if (!semver.prerelease(tag)) {
+            // include all non-prerelease versions
+            return true;
+          }
+          // check if the name of the prerelease matches the one we are looking for
+          if (semver.prerelease(tag)[0] === prerelease) {
+            return true;
+          }
+          return false;
+        });
+      }
       // ensure that the largest semver tag is at the head.
       tags = tags.map((tag) => {
         return semver.clean(tag);

--- a/test/git.integration-test.js
+++ b/test/git.integration-test.js
@@ -272,6 +272,14 @@ describe('git', function () {
       const output = shell.exec('git tag');
       expect(output.stdout).toContain('v5.1.0');
     });
+
+    it('uses only relevant prerelease tags', async function () {
+      shell.rm('package.json');
+      mock({ bump: 'minor', tags: ['v1.1.0-b.0', 'v1.1.0-a.0', 'v1.0.0-b.0'] });
+      await exec('--prerelease a');
+      const output = shell.exec('git tag');
+      expect(output.stdout).toContain('1.1.0-a.1');
+    });
   });
 
   describe('Run ... to publish', function () {


### PR DESCRIPTION
This relates to issue https://github.com/absolute-version/commit-and-tag-version/issues/211

If we have already git tags:
- v1.0.0-a.0
- v1.0.0-b.0
and then try to determine the next tag for prerelease `a`, we get `v1.0.0-a.0` (which already exists). 
This is because `lib/latest-semver-tag.js` was returning the latest tag, even if it was different prerelease (`b` in this case).

This PR adds filtering to remove prerelease tags for different prereleases, and only then selecting latest