### PR TITLE
fix: add all commits when using -a flag

### DIFF
--- a/lib/lifecycles/commit.js
+++ b/lib/lifecycles/commit.js
@@ -60,7 +60,7 @@ async function execCommit(args, newVersion) {
   await runExecFile(
     args,
     'git',
-    ['commit'].concat(verify, sign, signoff, args.commitAll ? [] : toAdd, [
+    ['commit'].concat(verify, sign, signoff, args.commitAll ? ['.'] : toAdd, [
       '-m',
       `${formatCommitMessage(args.releaseCommitMessageFormat, newVersion)}`,
     ]),


### PR DESCRIPTION
The -a flag doesn't work, it has absolutely no effect.
This ensures that a "." is added to the commit command when all commits are to be added.

Closes #217