### PR TITLE
refactor: use `fast-xml-parser` to parse and build XML

### DIFF
--- a/lib/updaters/types/maven.js
+++ b/lib/updaters/types/maven.js
@@ -1,40 +1,39 @@
-const jsdom = require('jsdom');
-const serialize = require('w3c-xmlserializer');
 const detectNewline = require('detect-newline');
+const { XMLParser, XMLBuilder } = require('fast-xml-parser');
+
 const CRLF = '\r\n';
 const LF = '\n';
 
 function pomDocument(contents) {
-  const dom = new jsdom.JSDOM('');
-  const parser = new dom.window.DOMParser();
-  return parser.parseFromString(contents, 'application/xml');
+  const parser = new XMLParser();
+  return parser.parse(contents);
 }
 
-function pomVersionElement(document) {
-  const versionElement = document.querySelector('project > version');
+function pomVersion(document) {
+  const version = document?.project?.version;
 
-  if (!versionElement) {
+  if (!version) {
     throw new Error(
       'Failed to read the version field in your pom file - is it present?',
     );
   }
 
-  return versionElement;
+  return version;
 }
 
 module.exports.readVersion = function (contents) {
   const document = pomDocument(contents);
-  return pomVersionElement(document).textContent;
+  return pomVersion(document);
 };
 
 module.exports.writeVersion = function (contents, version) {
   const newline = detectNewline(contents);
   const document = pomDocument(contents);
-  const versionElement = pomVersionElement(document);
 
-  versionElement.textContent = version;
+  document.project.version = version;
 
-  const xml = serialize(document);
+  const builder = new XMLBuilder({format: true});
+  const xml = builder.build(document);
 
   if (newline === CRLF) {
     return xml.replace(/\n/g, CRLF) + CRLF;

--- a/package.json
+++ b/package.json
@@ -47,12 +47,11 @@
     "detect-indent": "^6.1.0",
     "detect-newline": "^3.1.0",
     "dotgitignore": "^2.1.0",
+    "fast-xml-parser": "^5.2.5",
     "figures": "^3.2.0",
     "find-up": "^5.0.0",
     "git-semver-tags": "^5.0.1",
-    "jsdom": "^25.0.1",
     "semver": "^7.6.3",
-    "w3c-xmlserializer": "^5.0.0",
     "yaml": "^2.6.0",
     "yargs": "^17.7.2"
   },


### PR DESCRIPTION
`jsdom` is quite a heavy library just to parse some XML content. ([2.7MB minified](https://bundlephobia.com/package/jsdom@26.1.0)) This replaces it with the parser of [`fast-xml-parser`](https://github.com/NaturalIntelligence/fast-xml-parser).

Since the result is a plain JS Object instead of a DOM node, we can also use the corresponding `XMLBuilder`.

The resulting XML is formatted differently, hence the failing tests. Since the previous solution also did not preserve formatting I think this is a reasonable side-effect. But I'm curious how this should be handled.