### PR TITLE
feat: add --config option to allow custom config file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ _Having problems? Want to contribute? Join us on the [node-tooling community Sla
     - [Release as a Pre-Release](#release-as-a-pre-release)
     - [Release as a Target Type Imperatively (`npm version`-like)](#release-as-a-target-type-imperatively-npm-version-like)
     - [Prevent Git Hooks](#prevent-git-hooks)
+    - [Custom Config Path](#custom-config-path)
     - [Signing Commits and Tags](#signing-commits-and-tags)
     - [Lifecycle Scripts](#lifecycle-scripts)
     - [Skipping Lifecycle Steps](#skipping-lifecycle-steps)
@@ -310,6 +311,23 @@ If you use git hooks, like pre-commit, to test your code before committing, you 
 npm run release -- --no-verify
 # or global bin
 commit-and-tag-version --no-verify
+```
+
+### Custom Config Path
+
+Specify a custom path to the configuration file using the `--config` option
+
+```sh
+commit-and-tag-version --config ./path/to/.versionrc.js
+
+# or using alias
+commit-and-tag-version -c ./path/to/.versionrc.js
+```
+
+All config file formats can be used:
+
+```sh
+commit-and-tag-version -c ./path/to/.versionrc[.js|.cjs|.json]
 ```
 
 ### Signing Commits and Tags

--- a/command.js
+++ b/command.js
@@ -132,6 +132,12 @@ const yargs = require('yargs')
     default: defaults.npmPublishHint,
     describe: 'Customized publishing hint',
   })
+  .option('config', {
+    type: 'string',
+    default: defaults.config,
+    alias: 'c',
+    describe: 'Path to a custom configuration file',
+  })
   .check((argv) => {
     if (typeof argv.scripts !== 'object' || Array.isArray(argv.scripts)) {
       throw Error('scripts must be an object');
@@ -150,8 +156,9 @@ const yargs = require('yargs')
   )
   .pkgConf('standard-version')
   .pkgConf('commit-and-tag-version')
-  .config(getConfiguration())
   .wrap(97);
+
+yargs.config(getConfiguration(yargs.argv.config));
 
 Object.keys(spec.properties).forEach((propertyKey) => {
   const property = spec.properties[propertyKey];

--- a/defaults.js
+++ b/defaults.js
@@ -17,6 +17,7 @@ const defaults = {
   gitTagFallback: true,
   preset: require.resolve('conventional-changelog-conventionalcommits'),
   npmPublishHint: undefined,
+  config: undefined,
 };
 
 /**

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -9,9 +9,13 @@ const CONFIGURATION_FILES = [
   '.versionrc.js',
 ];
 
-module.exports.getConfiguration = function () {
+module.exports.getConfiguration = function (configFile) {
   let config = {};
-  const configPath = findUp.sync(CONFIGURATION_FILES);
+
+  // If the user has provided a configuration file via the `--config` argument, we use that.
+  const configurationFiles = configFile ?? CONFIGURATION_FILES;
+
+  const configPath = findUp.sync(configurationFiles);
   if (!configPath) {
     return config;
   }

--- a/test/config-files.integration-test.js
+++ b/test/config-files.integration-test.js
@@ -86,6 +86,30 @@ describe('config files', function () {
     expect(content).toContain(issueUrlFormat);
   });
 
+  it('reads config from custom path', async function () {
+    const issueUrlFormat = 'http://www.foo.com/{{id}}';
+    const changelog = ({ preset }) => preset.issueUrlFormat;
+    mock({ bump: 'minor', changelog });
+    fs.mkdirSync('custom-folder');
+    fs.writeFileSync(
+      'custom-folder/.versionrc.json',
+      JSON.stringify({ issueUrlFormat }),
+      'utf-8',
+    );
+
+    // Override process.argv to simulate CLI arguments before `exec`.
+    // This ensures yargs parses the custom config argument.
+    const originalArgv = process.argv;
+    process.argv = ['node', 'script.js', '-c', 'custom-folder/.versionrc.json'];
+
+    await exec(['-c', 'custom-folder/.versionrc.json']);
+    const content = fs.readFileSync('CHANGELOG.md', 'utf-8');
+    expect(content).toContain(issueUrlFormat);
+
+    // Restore original process.argv
+    process.argv = originalArgv;
+  });
+
   it('evaluates a config-function from .versionrc.js', async function () {
     const issueUrlFormat = 'http://www.foo.com/{{id}}';
     const src = `module.exports = function() { return ${JSON.stringify({


### PR DESCRIPTION
Closes #236 

## Summary:
This pull request adds support for a `--config` option to allow users to specify a custom configuration file path.

## Changes:
- Adds a `--config` (`-c`) CLI argument using yargs.
- Includes tests verifying that the custom config file is correctly parsed.
- Updates documentation.