### PR TITLE
gradle.js fix versionRegex to handle prerelease

### DIFF
--- a/lib/updaters/types/gradle.js
+++ b/lib/updaters/types/gradle.js
@@ -1,4 +1,4 @@
-const versionRegex = /^version\s+=\s+['"]([\d.]+.*)['"]/m;
+const versionRegex = /^version\s*=\s*['"]([\d.]+.*)['"]/m;
 
 module.exports.readVersion = function (contents) {
   const matches = versionRegex.exec(contents);


### PR DESCRIPTION
Updater lib/updaters/types/gradle.js has too narrow regex for version: `/^version\s+=\s+['"]([\d.]+)['"]/m`, it handles only version like x.y.z while prerelease looks like x.y.z-pre.a (where x,y,z,a are numbers).
Change to `/^version\s*=\s*['"]([\d.]+.*)['"]/m`