### PR TITLE
chore(publishing): Update Node.js version and npm publish configuration

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,10 +27,12 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
+        if: ${{ steps.release.outputs.release_created }}
+      - run: npm install -g npm@latest
         if: ${{ steps.release.outputs.release_created }}
       - run: npm ci
         if: ${{ steps.release.outputs.release_created }}
-      - run: npm publish
+      - run: npm publish --provenance
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Publishing using Trusted Publishing isn't working. This PR tries to fix it by updating the release workflow to use Node.js 22, upgrading npm to the latest version, and enable the provenance flag (which is meant to be on by default, but now it's definitely on)

Thanks again to Claude for these suggestions.

BEGIN_COMMIT_OVERRIDE
END_COMMIT_OVERRIDE