### PR TITLE
fix(maven): preserve comments in pom.xml

### DIFF
--- a/lib/updaters/types/maven.js
+++ b/lib/updaters/types/maven.js
@@ -12,6 +12,8 @@ function pomDocument(contents) {
     parseTagValue: false,
     // Don't coerce attribute values to numbers/booleans (e.g. keep port="8080" as a string)
     parseAttributeValue: false,
+    // Preserve comments
+    commentPropName: "#comment",
   });
   return parser.parse(contents);
 }
@@ -45,6 +47,8 @@ module.exports.writeVersion = function (contents, version) {
     // Write fork="true" instead of shorthand fork (which is invalid in XML)
     suppressBooleanAttributes: false,
     format: true,
+    // Preserve comments
+    commentPropName: "#comment",
   });
   const xml = builder.build(document);
 

--- a/test/mocks/pom-6.3.1-attrs-lf.xml
+++ b/test/mocks/pom-6.3.1-attrs-lf.xml
@@ -3,6 +3,7 @@
   <groupId>com.mycompany.app</groupId>
   <artifactId>my-module</artifactId>
   <version>6.3.1</version>
+  <!-- preserved-comment -->
   <build>
     <plugins>
       <plugin>

--- a/test/mocks/pom-6.4.0-attrs-lf.xml
+++ b/test/mocks/pom-6.4.0-attrs-lf.xml
@@ -3,6 +3,7 @@
   <groupId>com.mycompany.app</groupId>
   <artifactId>my-module</artifactId>
   <version>6.4.0</version>
+  <!-- preserved-comment -->
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Modifies the XML parser/builder config in the `maven` updater in order to preserve comments across version bumps in the `pom.xml`. Comments may be conveying useful information that shouldn't be lost, and in the case of tools like renovate, they can themselves be a form of configuration.