### PR TITLE
feat: support ESM configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,9 @@ You can configure `commit-and-tag-version` either by:
    > Note for users who have migrated to
    > `commit-and-tag-version` from `standard-version`: the previous package.json configuration key of `standard-version` will still work.
 
-2. Creating a `.versionrc`, `.versionrc.json` or `.versionrc.js`.
+2. Creating a `.versionrc`, `.versionrc.json`, `.versionrc.js`, `.versionrc.cjs` or `.versionrc.mjs`.
 
-- If you are using a `.versionrc.js` your default export must be a configuration object, or a function returning a configuration object.
+- If you are using a `.versionrc.js`, `.versionrc.cjs` or `.versionrc.mjs` your default export must be a configuration object, or a function returning a configuration object. Both CommonJS and ES module configs are supported (ES module configs require Node.js >= 22.12).
 
 Any of the command line parameters accepted by `commit-and-tag-version` can instead
 be provided via configuration. Please refer to the [conventional-changelog-config-spec](https://github.com/conventional-changelog/conventional-changelog-config-spec/) for details on available configuration options.
@@ -342,7 +342,7 @@ commit-and-tag-version -c ./path/to/.versionrc.js
 All config file formats can be used:
 
 ```sh
-commit-and-tag-version -c ./path/to/.versionrc[.js|.cjs|.json]
+commit-and-tag-version -c ./path/to/.versionrc[.js|.cjs|.mjs|.json]
 ```
 
 ### Signing Commits and Tags

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -8,6 +8,7 @@ const require = createRequire(import.meta.url);
 const CONFIGURATION_FILES = [
   '.versionrc',
   '.versionrc.cjs',
+  '.versionrc.mjs',
   '.versionrc.json',
   '.versionrc.js',
 ];
@@ -23,8 +24,17 @@ export function getConfiguration(configFile) {
     return config;
   }
   const ext = path.extname(configPath);
-  if (ext === '.js' || ext === '.cjs') {
-    const jsConfiguration = require(configPath);
+  if (ext === '.js' || ext === '.cjs' || ext === '.mjs') {
+    let jsConfiguration = require(configPath);
+    // ES modules arrive as a namespace wrapper (via Node's `require(esm)`,
+    // available since 22.12); the configuration is its default export.
+    if (
+      jsConfiguration != null &&
+      (jsConfiguration.__esModule ||
+        jsConfiguration[Symbol.toStringTag] === 'Module')
+    ) {
+      jsConfiguration = jsConfiguration.default;
+    }
     if (typeof jsConfiguration === 'function') {
       config = jsConfiguration();
     } else {

--- a/test/esm-config.integration-test.js
+++ b/test/esm-config.integration-test.js
@@ -1,0 +1,97 @@
+import shell from 'shelljs';
+import fs from 'fs';
+import { execFileSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const CLI = fileURLToPath(new URL('../bin/cli.js', import.meta.url));
+
+/**
+ * These tests spawn the real CLI in a child process instead of using the usual
+ * in-process harness. That is deliberate: `getConfiguration` loads ESM config
+ * files through Node's `require(esm)` (available since 22.12), and under vitest
+ * that require is intercepted by the module runner, which throws a Babel
+ * SyntaxError on ESM sources — a failure mode that does not exist in
+ * production. Only a child process observes the real behavior.
+ */
+
+function setupTestDirectory() {
+  shell.rm('-rf', 'esm-config-temp');
+  shell.config.silent = true;
+  shell.mkdir('esm-config-temp');
+  shell.cd('esm-config-temp');
+  shell.exec('git init');
+  shell.exec('git config commit.gpgSign false');
+  shell.exec('git config core.autocrlf false');
+  shell.exec('git commit --allow-empty -m"root-commit"');
+}
+
+function resetShell() {
+  shell.cd('../');
+  shell.rm('-rf', 'esm-config-temp');
+}
+
+function runCli() {
+  return execFileSync(process.execPath, [CLI, '--dry-run'], {
+    encoding: 'utf-8',
+  });
+}
+
+describe('ESM config files', function () {
+  beforeEach(function () {
+    setupTestDirectory();
+
+    fs.writeFileSync(
+      'package.json',
+      JSON.stringify({ version: '1.0.0' }),
+      'utf-8',
+    );
+  });
+
+  afterEach(function () {
+    resetShell();
+  });
+
+  it('reads an ES module config-object from .versionrc.js', function () {
+    fs.writeFileSync(
+      '.versionrc.js',
+      'export default { tagPrefix: "custom-" }',
+      'utf-8',
+    );
+
+    const output = runCli();
+    expect(output).toContain('tagging release custom-1.0.1');
+  });
+
+  it('reads an ES module config from .versionrc.mjs', function () {
+    fs.writeFileSync(
+      '.versionrc.mjs',
+      'export default { tagPrefix: "custom-" }',
+      'utf-8',
+    );
+
+    const output = runCli();
+    expect(output).toContain('tagging release custom-1.0.1');
+  });
+
+  it('evaluates an ES module config-function', function () {
+    fs.writeFileSync(
+      '.versionrc.mjs',
+      'export default function () { return { tagPrefix: "custom-" }; }',
+      'utf-8',
+    );
+
+    const output = runCli();
+    expect(output).toContain('tagging release custom-1.0.1');
+  });
+
+  it('applies the same configuration when written as CommonJS', function () {
+    fs.writeFileSync(
+      '.versionrc.js',
+      'module.exports = { tagPrefix: "custom-" }',
+      'utf-8',
+    );
+
+    const output = runCli();
+    expect(output).toContain('tagging release custom-1.0.1');
+  });
+});


### PR DESCRIPTION
## Summary

Adds support for ES module configuration files: `.versionrc.mjs`, and `.versionrc.js` written with `export default` (object or function). CommonJS configs behave exactly as before.

## Background

On Node >= 22.12, `require()` of an ES module succeeds (unflagged `require(esm)`) and returns a module-namespace wrapper (`{ __esModule: true, default: {...} }`). `getConfiguration` never unwrapped it, so an ESM `.versionrc.js` loaded **without any error while the user's configuration was silently ignored** — verified with the real CLI, where an ESM config's `tagPrefix` was not applied while the identical CommonJS config's was.

## Changes

- `lib/configuration.js`: add `.versionrc.mjs` to the config-file list, route `.mjs` through the JS loading branch, and unwrap the module-namespace wrapper (detected via `__esModule` / `Symbol.toStringTag === 'Module'`) to its `default` export before the existing function-vs-object handling. `getConfiguration` remains synchronous — no `import()`, no API change. The unwrap also covers Babel/TS-transpiled configs, which set `__esModule` themselves.
- `test/esm-config.integration-test.js` (new): four tests — ESM object in `.versionrc.js`, ESM object in `.versionrc.mjs`, ESM default-exported function, and a CommonJS control. These spawn `bin/cli.js --dry-run` in a child process because vitest's module runner intercepts `createRequire` and throws a Babel SyntaxError on ESM sources, a failure mode that doesn't exist in production; only a child process observes real `require(esm)` behavior.
- `README.md`: document the new formats and the Node >= 22.12 floor for ESM configs.

## Notes

- `engines` is `>=22`, but `require(esm)` was unflagged in 22.12 — on Node 22.0–22.11 an ESM config fails with Node's own `ERR_REQUIRE_ESM`. Documented in the README rather than adding a catch-and-rethrow; happy to add a friendlier error if preferred.

## Test plan

- [x] `npm test` — 142 tests passing, plus eslint and prettier checks
- [x] New child-process integration tests cover ESM object / ESM function / `.mjs` / CJS control

🤖 Generated with [Claude Code](https://claude.com/claude-code)