### PR TITLE
fix(yaml): preserve long scalar lines

### DIFF
--- a/lib/updaters/types/openapi.js
+++ b/lib/updaters/types/openapi.js
@@ -11,5 +11,5 @@ export function writeVersion(contents, version) {
 
   document.get('info').set('version', version);
 
-  return document.toString().replace(/\r?\n/g, newline);
+  return document.toString({ lineWidth: 0 }).replace(/\r?\n/g, newline);
 }

--- a/lib/updaters/types/yaml.js
+++ b/lib/updaters/types/yaml.js
@@ -11,5 +11,5 @@ export function writeVersion(contents, version) {
 
   document.set('version', version);
 
-  return document.toString().replace(/\r?\n/g, newline);
+  return document.toString({ lineWidth: 0 }).replace(/\r?\n/g, newline);
 }

--- a/test/yaml-updaters.spec.js
+++ b/test/yaml-updaters.spec.js
@@ -1,0 +1,20 @@
+import { writeVersion as writeOpenApiVersion } from '../lib/updaters/types/openapi.js';
+import { writeVersion as writeYamlVersion } from '../lib/updaters/types/yaml.js';
+
+const description = 'word '.repeat(30).trim();
+
+describe('YAML updaters', function () {
+  it('does not wrap long lines in YAML files', function () {
+    const contents = `version: 1.2.3\ndescription: ${description}\n`;
+    const expected = `version: 1.3.0\ndescription: ${description}\n`;
+
+    expect(writeYamlVersion(contents, '1.3.0')).toEqual(expected);
+  });
+
+  it('does not wrap long lines in OpenAPI files', function () {
+    const contents = `openapi: 3.0.3\ninfo:\n  title: Example\n  version: 1.2.3\n  description: ${description}\npaths: {}\n`;
+    const expected = `openapi: 3.0.3\ninfo:\n  title: Example\n  version: 1.3.0\n  description: ${description}\npaths: {}\n`;
+
+    expect(writeOpenApiVersion(contents, '1.3.0')).toEqual(expected);
+  });
+});


### PR DESCRIPTION
Disables automatic line wrapping in the YAML and OpenAPI updaters so version bumps leave long scalar values on one line. Adds regression coverage for both updater types.

Tests: `npm test`

Fixes #214.
