### PR TITLE
fix: document and support custom writer render functions

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -42,10 +42,52 @@ The content of the changelog is otherwise unchanged. This only affects newly gen
 
 The new conventional-changelog packages require Node.js >= 22, so `commit-and-tag-version` now does too. Node 20 reached end-of-life in April 2026, so I expect this won't affect most users.
 
+### Custom writer templates use render functions
+
+[conventional-changelog v8.0.0](https://github.com/conventional-changelog/conventional-changelog/releases/tag/conventional-changelog-v8.0.0) replaced Handlebars template strings and partial files with JavaScript render functions ([#1477](https://github.com/conventional-changelog/conventional-changelog/issues/1477)). The following `writerOpts` options must now be functions:
+
+- `template`
+- `headerPartial`
+- `commitPartial`
+- `footerPartial`
+
+The old `mainTemplate` option must be migrated to `template(context)`. The official [`@conventional-changelog/template` helpers](https://conventional-changelog.js.org/template/) provide Markdown, URL, repository and composition helpers for building these render functions.
+
+Before:
+
+```js
+module.exports = {
+  writerOpts: {
+    mainTemplate: '...',
+    commitPartial: '- {{subject}}',
+  },
+};
+```
+
+After:
+
+```js
+import { words } from '@conventional-changelog/template';
+
+function commitPartial(_context, commit) {
+  return words(commit.subject || commit.header, commit.shortHash);
+}
+
+export default {
+  writerOpts: {
+    commitPartial,
+  },
+};
+```
+
+If you customized the main template, implement `template(context)` as well instead of continuing to use `mainTemplate`.
+
+ESM `.versionrc.js` and `.versionrc.mjs` configurations require [`commit-and-tag-version` 13.1.0](https://github.com/absolute-version/commit-and-tag-version/releases/tag/v13.1.0) or newer. Although `@conventional-changelog/template` is a direct dependency of `commit-and-tag-version`, a configuration file that imports it directly should also declare it as a direct dependency of the user project. This is required by strict dependency managers such as pnpm.
+
 ### Behaviour that is intentionally preserved
 
 The upstream packages made some breaking changes that `commit-and-tag-version` shields you from, so no action is needed for these — they're listed here for the record:
 
 - **`types[].hidden` and the URL format options still work.** conventional-changelog-conventionalcommits 10 replaced `types[].hidden` with `types[].effect`, and replaced the `commitUrlFormat`, `compareUrlFormat`, `issueUrlFormat` and `userUrlFormat` template strings with callback functions. `commit-and-tag-version` translates the [config-spec](https://github.com/conventional-changelog/conventional-changelog-config-spec) options for you, so existing configuration keeps working. (If you supply the new-style `effect` / `format*Url` options, they're passed through untouched.)
 - **Version bump recommendations are unchanged.** The new preset only recommends a release when there's at least one `feat`, `fix`, `perf`, `revert` or breaking change; `commit-and-tag-version` keeps its historical behaviour of always recommending at least a patch. Use `--noBumpWhenEmptyChanges` if you don't want a release when there are no relevant commits, as before. In a future major release, we might change this default, depending on feedback.
-- **`parserOpts` and `writerOpts` overrides work as before**, merged over the preset's options.
+- **`parserOpts` and non-template `writerOpts` overrides work as before**, merged over the preset's options. Custom writer templates are the exception and must use the render functions described above.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@conventional-changelog/git-client": "3.1.0",
+        "@conventional-changelog/template": "1.2.1",
         "chalk": "^6.0.0",
         "conventional-changelog": "8.1.0",
         "conventional-changelog-config-spec": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "homepage": "https://github.com/absolute-version/commit-and-tag-version#readme",
   "dependencies": {
     "@conventional-changelog/git-client": "3.1.0",
+    "@conventional-changelog/template": "1.2.1",
     "chalk": "^6.0.0",
     "conventional-changelog": "8.1.0",
     "conventional-changelog-config-spec": "2.1.0",

--- a/test/esm-config.integration-test.js
+++ b/test/esm-config.integration-test.js
@@ -1,6 +1,6 @@
 import shell from 'shelljs';
 import fs from 'fs';
-import { execFileSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 
 const CLI = fileURLToPath(new URL('../bin/cli.js', import.meta.url));
@@ -60,6 +60,34 @@ describe('ESM config files', function () {
 
     const output = runCli();
     expect(output).toContain('tagging release custom-1.0.1');
+  });
+
+  it('renders a custom writer function imported by an ES module config', function () {
+    fs.writeFileSync(
+      '.versionrc.js',
+      `import { words } from '@conventional-changelog/template'
+
+function commitPartial(_context, commit) {
+  return words(commit.subject || commit.header, commit.shortHash)
+}
+
+export default {
+  writerOpts: {
+    commitPartial,
+  },
+}`,
+      'utf-8',
+    );
+    shell.exec('git commit --allow-empty -m"fix: render custom writer"');
+
+    const result = spawnSync(process.execPath, [CLI, '--dry-run'], {
+      encoding: 'utf-8',
+    });
+    const output = `${result.stdout}${result.stderr}`;
+
+    expect(result.status).toBe(0);
+    expect(output).toContain('render custom writer');
+    expect(output).not.toContain('commitPartial is not a function');
   });
 
   it('reads an ES module config from .versionrc.mjs', function () {


### PR DESCRIPTION
## Summary

- add `@conventional-changelog/template@1.2.1` as a direct runtime dependency
- cover function-based `writerOpts.commitPartial` imported from an ESM `.versionrc.js`
- document the conventional-changelog v8 custom writer template migration

## Root cause

Version 13 upgraded conventional-changelog from v4 to v8, where Handlebars template strings and partial files were replaced by JavaScript render functions.

The v13 migration guide still stated that `writerOpts` overrides worked as before, which incorrectly implied that the removed Handlebars template interface
remained compatible. The official template helpers were also only available transitively rather than being declared as a supported runtime dependency.

## Implementation

- declare `@conventional-changelog/template@1.2.1` as a direct dependency
- add a real CLI dry-run regression test using:
  - an ESM `.versionrc.js`
  - the official `words` helper
  - a function-based `writerOpts.commitPartial`
  - a conventional commit included in the generated changelog
- document:
  - the render-function migration
  - `mainTemplate` to `template(context)`
  - the affected writer options
  - ESM configuration version requirements
  - direct dependency requirements under strict package managers such as pnpm

## Validation

- `npm exec vitest run test/esm-config.integration-test.js`
- `npm test`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

## Non-goals

- no changes to the ESM configuration loader
- no new `commit-and-tag-version/template` subpath export
- no changes to changelog generation
- no changes to default preset behavior
- no changes to Node.js engines
- no unrelated dependency upgrades or refactoring

Fixes #323