### PR TITLE
docs: Tiny tweak to README: how to skip lifecycle steps via command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,8 @@ by adding the following to your package.json:
 }
 ```
 
+To set these options via the command line, use `commit-and-tag-version --skip.changelog`
+
 ### Committing Generated Artifacts in the Release Commit
 
 If you want to commit generated artifacts in the release commit, you can use the `--commit-all` or `-a` flag. You will need to stage the artifacts you want to commit, so your `release` command could look like this:


### PR DESCRIPTION
Tiny README tweak to help with understanding how to skip steps via the command line, as discussed at https://github.com/absolute-version/commit-and-tag-version/issues/327#issuecomment-5309959787