### PR TITLE
fix: keep feat at minor under preMajor — pre-1.0 features were silently released as patches

### DIFF
--- a/lib/lifecycles/bump.js
+++ b/lib/lifecycles/bump.js
@@ -75,7 +75,13 @@ function legacyWhatBump(config, commits) {
     }
   });
 
-  if (config.preMajor && level < 2) {
+  if (config.preMajor && level === 0) {
+    // SemVer 0.x "softening" (5d972cf): breaking → minor (0→1) only.
+    // Downgrading feat as well (level < 2, added in c2d26bf) made every
+    // feature in a 0.x repo a patch release — semantically a fix — which
+    // silently mislabeled releases for all pre-1.0 projects (13.1.2
+    // regression, downstream awesome-rules#42 hit it with 44 feat commits
+    // recommending a patch bump).
     level++;
   }
 

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -1836,6 +1836,50 @@ describe('cli', function () {
         await exec('-r major');
         verifyPackageVersion({ writeFileSyncSpy, expectedVersion: '1.0.0' });
       });
+
+      it('keeps feat at minor when version < 1.0.0 (no preMajor downgrade past minor)', async function () {
+        // Regression (13.1.2): legacyWhatBump downgraded feat (minor) to
+        // patch under preMajor, so 0.x projects shipped every feature as a
+        // patch release. preMajor softening applies to breaking changes only
+        // (major → minor); feat must stay minor.
+        mock({
+          bump: mockers.actualConventionalRecommendedBump,
+          changelog: ['feat release\n'],
+          tags: ['v0.5.0'],
+          commits: ['feat: shiny new stuff\n\n-hash-\nabc123\n'],
+          testFiles: [
+            {
+              path: 'package.json',
+              value: {
+                version: '0.5.0',
+                repository: { url: 'https://github.com/yargs/yargs.git' },
+              },
+            },
+          ],
+        });
+        await exec();
+        verifyPackageVersion({ writeFileSyncSpy, expectedVersion: '0.6.0' });
+      });
+
+      it('softens breaking change to minor (not patch) when version < 1.0.0', async function () {
+        mock({
+          bump: mockers.actualConventionalRecommendedBump,
+          changelog: ['breaking release\n'],
+          tags: ['v0.5.0'],
+          commits: ['feat!: this is a breaking change\n\n-hash-\nabc123\n'],
+          testFiles: [
+            {
+              path: 'package.json',
+              value: {
+                version: '0.5.0',
+                repository: { url: 'https://github.com/yargs/yargs.git' },
+              },
+            },
+          ],
+        });
+        await exec();
+        verifyPackageVersion({ writeFileSyncSpy, expectedVersion: '0.6.0' });
+      });
     });
   });
 


### PR DESCRIPTION
## Problem

In a **pre-1.0 repository** (`version < 1.0.0`), a `feat` commit is recommended as a **patch** bump instead of **minor**:

```
$ git init -b main && echo '{"version":"0.1.0"}' > package.json
$ git add -A && git commit -m 'chore: init' && git tag -a v0.1.0 -m x
$ echo x > f && git add -A && git commit -m 'feat: test feature'
$ npx commit-and-tag-version --dry-run
✔ bumping version in package.json from 0.1.0 to 0.1.1     ← expected 0.2.0
```

Reproduced on master (13.1.2).

## Root cause

`lib/lifecycles/bump.js` — `legacyWhatBump` applies the preMajor downshift to *any* level below 2:

```js
if (config.preMajor && level < 2) {
  level++;
}
```

A `feat` computes level 1 (minor); the guard shifts it to 2 (patch). The preMajor semantics introduced in 5d972cf soften **breaking changes only** (major → minor, level 0 → 1) — the changelog preset's own `whatBump` applies the same `level++` but its level starts from a different scale where the same intent lands correctly; the legacy copy in this repo got the guard boundary wrong when the logic was copied in c2d26bf.

## Fix

Narrow the guard to the breaking-change level only:

```js
if (config.preMajor && level === 0) {
  level++;
}
```

| commit | before (0.5.0) | after (0.5.0) |
|---|---|---|
| `feat` | 0.5.1 ❌ | **0.6.0** ✅ |
| `feat!` / breaking | 0.6.0 ✅ | 0.6.0 ✅ (softening preserved) |
| `fix` | 0.5.1 ✅ | 0.5.1 ✅ (unchanged) |

## Tests

Two regression cases using the real recommended-bump chain (`actualConventionalRecommendedBump` sentinel, per the existing pattern in `core.spec.js`):

- `feat` on 0.5.0 → expects `0.6.0` (fails on master, passes with the fix)
- breaking change on 0.5.0 → expects `0.6.0` (guards the softening behavior against future overcorrection)

Verified: new test red on master (1 failed), green after fix; full suite `151 passed`; `npm run lint` clean.

## Downstream impact

Every 0.x project using the default preset has been shipping features as patch releases. Real-world report: awesome-rules v0.4.0 had 44 `feat` commits since v0.3.0 and the tool recommended `0.3.1` — had to work around with `--release-as 0.4.0`.