### PR TITLE
fix: bring back the blank line between release notes sections

### DIFF
--- a/lib/lifecycles/changelog.js
+++ b/lib/lifecycles/changelog.js
@@ -97,7 +97,7 @@ async function outputChangelog(args, newVersion) {
       changelogFrontMatter +
         header +
         '\n' +
-        (content + oldContentBody).replace(/\n+$/, '\n'),
+        (content + '\n' + oldContentBody).replace(/\n+$/, '\n'),
     );
 }
 

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -389,7 +389,13 @@ describe('cli', function () {
       verifyNewChangelogContentEquals({
         writeFileSyncSpy,
         expectedContent:
-          frontMatter + '\n' + header + '\n' + changelog101 + changelog100,
+          frontMatter +
+          '\n' +
+          header +
+          '\n' +
+          changelog101 +
+          '\n' +
+          changelog100,
       });
     });
 
@@ -417,7 +423,13 @@ describe('cli', function () {
       verifyNewChangelogContentEquals({
         writeFileSyncSpy,
         expectedContent:
-          frontMatter + '\n' + header + '\n' + changelog101 + changelog100,
+          frontMatter +
+          '\n' +
+          header +
+          '\n' +
+          changelog101 +
+          '\n' +
+          changelog100,
       });
     });
 
@@ -446,7 +458,7 @@ describe('cli', function () {
       await exec();
       verifyNewChangelogContentEquals({
         writeFileSyncSpy,
-        expectedContent: header + '\n' + changelog2 + changelog1,
+        expectedContent: header + '\n' + changelog2 + '\n' + changelog1,
       });
     });
 


### PR DESCRIPTION
A one-liner that fixes #311 

More context: https://github.com/conventional-changelog/conventional-changelog/issues/1511#issuecomment-5043607232

@TimothyJones acknowledged this issue in https://github.com/absolute-version/commit-and-tag-version/issues/311#issuecomment-5165189228, but looks like he forgot about it
